### PR TITLE
Update Java version to 17 for Jenkins compatibility

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -27,7 +27,7 @@
 		<url/>
 	</scm>
 	<properties>
-		<java.version>23</java.version>
+		<java.version>17</java.version>
 	</properties>
 	<dependencies>
 		<dependency>


### PR DESCRIPTION
- Updated Java version from 23 to 17 in pom.xml
- Change required for Jenkins compatibility

![image](https://github.com/user-attachments/assets/177f15e6-e39d-4e79-b41b-f15832bf2ee7)
