### PR TITLE
Update CORS configuration to allow frontend communication

### DIFF
--- a/src/main/java/com/anonymousibex/Agents/of/Revature/config/WebConfig.java
+++ b/src/main/java/com/anonymousibex/Agents/of/Revature/config/WebConfig.java
@@ -14,8 +14,14 @@ public class WebConfig implements WebMvcConfigurer {
     @Override
     public void addCorsMappings(CorsRegistry registry) {
         registry.addMapping("/**")
-                .allowedOrigins(allowedOrigin)
-                .allowedMethods("GET", "POST", "PUT", "DELETE", "OPTIONS")
-                .allowCredentials(true);
+                .allowedOrigins(
+                    "http://localhost:8082",  // Frontend container port
+                    "http://localhost:5173",  // Development port
+                    "http://frontend:80"      // Docker network name
+                )
+                .allowedMethods("GET", "POST", "PUT", "DELETE", "OPTIONS", "PATCH")
+                .allowedHeaders("*")
+                .allowCredentials(true)
+                .maxAge(3600);
     }
 }


### PR DESCRIPTION
   This PR updates the CORS configuration in WebConfig.java to allow:
   - Frontend container communication (port 8082)
   - Development environment (port 5173)
   - Docker network communication
   
   Changes:
   - Added multiple allowed origins
   - Added support for PATCH method
   - Added allowed headers
   - Set CORS preflight cache time