### PR TITLE
removed role from user, added auto drop in app.props, added testing f…

### DIFF
--- a/src/main/java/com/anonymousibex/Agents/of/Revature/config/SessionAuthenticationFilter.java
+++ b/src/main/java/com/anonymousibex/Agents/of/Revature/config/SessionAuthenticationFilter.java
@@ -13,6 +13,7 @@ import org.springframework.stereotype.Component;
 import org.springframework.web.filter.OncePerRequestFilter;
 
 import java.io.IOException;
+import java.util.Collections;
 import java.util.List;
 
 @Component
@@ -33,7 +34,7 @@ public class SessionAuthenticationFilter extends OncePerRequestFilter {
             if (userId != null) {
                 userRepository.findById(userId).ifPresent(user -> {
                     UsernamePasswordAuthenticationToken auth = new UsernamePasswordAuthenticationToken(
-                            user, null, List.of(new SimpleGrantedAuthority("ROLE_" + user.getRole().name()))
+                            user, null, Collections.emptyList()
                     );
                     SecurityContextHolder.getContext().setAuthentication(auth);
                 });

--- a/src/main/java/com/anonymousibex/Agents/of/Revature/dto/UserDto.java
+++ b/src/main/java/com/anonymousibex/Agents/of/Revature/dto/UserDto.java
@@ -1,6 +1,5 @@
 package com.anonymousibex.Agents.of.Revature.dto;
 
-import com.anonymousibex.Agents.of.Revature.model.Role;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 
@@ -9,5 +8,4 @@ import lombok.Data;
 public class UserDto {
     private Long id;
     private String username;
-    private Role role;
 }

--- a/src/main/java/com/anonymousibex/Agents/of/Revature/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/anonymousibex/Agents/of/Revature/exception/GlobalExceptionHandler.java
@@ -56,16 +56,6 @@ public class GlobalExceptionHandler {
         return ExceptionResponseUtils.buildResponse(ex.getMessage(), HttpStatus.UNAUTHORIZED);
     }
 
-    @ExceptionHandler(ItemNameExistsException.class)
-    public ResponseEntity<ResponseDto> handleItemNameExists(ItemNameExistsException ex) {
-        return ExceptionResponseUtils.buildResponse(ex.getMessage(), HttpStatus.CONFLICT);
-    }
-
-    @ExceptionHandler(NoSuchElementException.class)
-    public ResponseEntity<ResponseDto> handleItemNotFound(NoSuchElementException ex) {
-        return ExceptionResponseUtils.buildResponse(ex.getMessage(), HttpStatus.BAD_REQUEST);
-    }
-
     @ExceptionHandler(NoUserResultsFoundException.class)
     public ResponseEntity<ResponseDto> handleNoUserResultsFound(NoUserResultsFoundException ex) {
         return ExceptionResponseUtils.buildResponse(ex.getMessage(), HttpStatus.NOT_FOUND);

--- a/src/main/java/com/anonymousibex/Agents/of/Revature/exception/ItemNameExistsException.java
+++ b/src/main/java/com/anonymousibex/Agents/of/Revature/exception/ItemNameExistsException.java
@@ -1,7 +1,0 @@
-package com.anonymousibex.Agents.of.Revature.exception;
-
-public class ItemNameExistsException extends RuntimeException {
-    public ItemNameExistsException(String message) {
-        super(message);
-    }
-}

--- a/src/main/java/com/anonymousibex/Agents/of/Revature/exception/NoSuchElementException.java
+++ b/src/main/java/com/anonymousibex/Agents/of/Revature/exception/NoSuchElementException.java
@@ -1,7 +1,0 @@
-package com.anonymousibex.Agents.of.Revature.exception;
-
-public class NoSuchElementException extends RuntimeException {
-    public NoSuchElementException(String message) {
-        super(message);
-    }
-}

--- a/src/main/java/com/anonymousibex/Agents/of/Revature/model/Role.java
+++ b/src/main/java/com/anonymousibex/Agents/of/Revature/model/Role.java
@@ -1,6 +1,0 @@
-package com.anonymousibex.Agents.of.Revature.model;
-
-public enum Role {
-    USER,
-    ADMIN
-}

--- a/src/main/java/com/anonymousibex/Agents/of/Revature/model/User.java
+++ b/src/main/java/com/anonymousibex/Agents/of/Revature/model/User.java
@@ -16,7 +16,5 @@ public class User {
     private String username;
     private String password;
 
-    @Enumerated(EnumType.STRING)
-    private Role role = Role.USER;
 
 }

--- a/src/main/java/com/anonymousibex/Agents/of/Revature/service/GeminiService.java
+++ b/src/main/java/com/anonymousibex/Agents/of/Revature/service/GeminiService.java
@@ -12,11 +12,9 @@ public class GeminiService {
 
     private static final int MAX_RETRIES = 2;
 
-    // Spring will inject your env var here:
     @Value("${GOOGLE_API_KEY}")
     private String googleApiKey;
 
-    // This Function is initialized *after* injection in @PostConstruct
     public Function<String, String> callGemini;
 
     @PostConstruct
@@ -30,9 +28,7 @@ public class GeminiService {
                         .text();
     }
 
-    /**
-     * Call Gemini with retries until validator passes.
-     */
+
     public String getValidResponse(
             String prompt,
             Function<String, Boolean> validator
@@ -52,9 +48,7 @@ public class GeminiService {
         );
     }
 
-    /**
-     * A helper for calls that don't require validation (e.g. final closing).
-     */
+
     public String generate(String prompt) {
         return callGemini.apply(prompt);
     }

--- a/src/main/java/com/anonymousibex/Agents/of/Revature/service/UserService.java
+++ b/src/main/java/com/anonymousibex/Agents/of/Revature/service/UserService.java
@@ -2,7 +2,6 @@ package com.anonymousibex.Agents.of.Revature.service;
 
 import com.anonymousibex.Agents.of.Revature.dto.UserDto;
 import com.anonymousibex.Agents.of.Revature.exception.*;
-import com.anonymousibex.Agents.of.Revature.model.Role;
 import com.anonymousibex.Agents.of.Revature.model.User;
 import com.anonymousibex.Agents.of.Revature.repository.UserRepository;
 import com.anonymousibex.Agents.of.Revature.util.UserUtils;
@@ -39,7 +38,6 @@ public class UserService {
         }
 
         user.setPassword(encoder.encode(password));
-        user.setRole(Role.USER);
         user.setUsername(username);
         return UserUtils.toUserDto(userRepository.save(user));
     }

--- a/src/main/java/com/anonymousibex/Agents/of/Revature/util/UserUtils.java
+++ b/src/main/java/com/anonymousibex/Agents/of/Revature/util/UserUtils.java
@@ -1,7 +1,6 @@
 package com.anonymousibex.Agents.of.Revature.util;
 
 import com.anonymousibex.Agents.of.Revature.dto.UserDto;
-import com.anonymousibex.Agents.of.Revature.model.Role;
 import com.anonymousibex.Agents.of.Revature.model.User;
 import jakarta.servlet.http.Cookie;
 import jakarta.servlet.http.HttpServletResponse;
@@ -24,9 +23,8 @@ public class UserUtils {
     public static UserDto toUserDto(User user){
         Long id = user.getId();
         String username = user.getUsername();
-        Role role = user.getRole();
 
-        return new UserDto(id, username, role);
+        return new UserDto(id, username);
     }
 
     public static void clearSessionCookie(HttpServletResponse response){

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -5,7 +5,7 @@ spring.datasource.username=${DB_USERNAME}
 spring.datasource.password=${DB_PASSWORD}
 spring.datasource.driver-class-name=org.postgresql.Driver
 
-spring.jpa.hibernate.ddl-auto=update
+spring.jpa.hibernate.ddl-auto=create-drop
 spring.jpa.properties.hibernate.dialect=org.hibernate.dialect.PostgreSQLDialect
 
 app.cors.allowedOrigins=http://localhost:5173, http://localhost:3000, http://localhost:8081, http://localhost:8082, http://52.90.31.202:8081/, http://52.90.31.202:8082/
@@ -15,5 +15,6 @@ spring.sql.init.mode=always
 spring.jpa.defer-datasource-initialization=true
 
 GOOGLE_API_KEY=${GOOGLE_API_KEY}
+
 
 logging.level.org.springframework.web=DEBUG

--- a/src/main/resources/data.sql
+++ b/src/main/resources/data.sql
@@ -1,21 +1,21 @@
 -- Ensure table exists (JPA usually handles this if ddl-auto is set)
 -- Insert test users (with BCrypt-hashed passwords)
 
-INSERT INTO users (id, password, role, username) VALUES
-  (1,   '$2a$10$Q9eV2kh5Dlttc2V4kI9LRe4Ev.5jXRphI6FE/ODG0Z.JPV1eHmt5W', 'USER',  'agent007'),
-  (2,   '$2a$10$ml03ENvpKYJ6AxyqZzlePuxAV6us3MC/mvZ3zSGZcK9Z6gAYU5Dsy', 'ADMIN', 'admin'),
-  (3,   '$2a$10$yT1FC4DRYZDkhw2SPRx5ROyt5BoRwh7PbCS6GzSGKQfppFErln28K', 'USER',  'testuser'),
-  (4,   '$2a$10$7W3PHwSOSE63456NZGq.AeuCH8r6gz49dDepMe8UJwAbDYwUXYrdi', 'USER',  'testuser2'), -- all passwords are Testtest1@
-  (197, '$2a$10$NQ8VjKtY/J507WzIhhFfqeJyJsUxVDzqwSvo3FAMwMvZb2eec3krO', 'USER',  'larry'),
-  (198, '$2a$10$/v8fF6qMFGE5jQaBVeZN6.zqR7dPiEmVkEzA5g0ml.mIzDryi/h9K', 'USER',  'gerald'),
-  (199, '$2a$10$3Td2/siw566ZxPB5dDzrNu7ixM5gyyjoRuxCIAcYFru9oBtRuxmzu', 'USER',  'filmore'),
-  (200, '$2a$10$aTWbwO.84Nk4XSB4JHVr1O7e4O2uMHS6UQGwVlW22lcI3Ll1vrqw2', 'USER',  'superman'),
-  (201, '$2a$10$z3whWUOA4B.Uqu2zwf2oi.5PzUQkpAfydtoKIR2qFYQs6nahNnaNO', 'USER',  'theb@ddest'),
-  (202, '$2a$10$A4/kfzh0MqM/Y5r38s8i3.SqXxPOgTwhfMnL5Nrx61R2Q7Pr6pnrW', 'USER',  'daniel'),
-  (203, '$2a$10$krCRwcxt6a/uzvjcbuae1OyulMh5dYrUfLFPE3SOn2yu7KfsLSSia', 'USER',  'carlos'),
-  (204, '$2a$10$JsL4WH.cUFTF4Yhwx8ONQeW0mD32xXZT4TlOaAWoCbnKe/xmV9vcu', 'USER',  'luis1'),
-  (205, '$2a$10$Bdpng4F7gQ3hi9K/Zax2Z.MH6ZA/anN6YS55tQdKv.ykWCt6eWLQy', 'USER',  'rose1'),
-  (206, '$2a$10$slJT6QliTTTbthIk9TMjuu8NmJdSEEPo40rDrq/PgbjU5GyPtZxVO', 'USER',  'josh1')
+INSERT INTO users (id, password, username) VALUES
+  (1,   '$2a$10$Q9eV2kh5Dlttc2V4kI9LRe4Ev.5jXRphI6FE/ODG0Z.JPV1eHmt5W',   'agent007'),
+  (2,   '$2a$10$ml03ENvpKYJ6AxyqZzlePuxAV6us3MC/mvZ3zSGZcK9Z6gAYU5Dsy',  'admin'),
+  (3,   '$2a$10$yT1FC4DRYZDkhw2SPRx5ROyt5BoRwh7PbCS6GzSGKQfppFErln28K',   'testuser'),
+  (4,   '$2a$10$7W3PHwSOSE63456NZGq.AeuCH8r6gz49dDepMe8UJwAbDYwUXYrdi',   'testuser2'), -- all passwords are Testtest1@
+  (197, '$2a$10$NQ8VjKtY/J507WzIhhFfqeJyJsUxVDzqwSvo3FAMwMvZb2eec3krO',   'larry'),
+  (198, '$2a$10$/v8fF6qMFGE5jQaBVeZN6.zqR7dPiEmVkEzA5g0ml.mIzDryi/h9K',   'gerald'),
+  (199, '$2a$10$3Td2/siw566ZxPB5dDzrNu7ixM5gyyjoRuxCIAcYFru9oBtRuxmzu',   'filmore'),
+  (200, '$2a$10$aTWbwO.84Nk4XSB4JHVr1O7e4O2uMHS6UQGwVlW22lcI3Ll1vrqw2',   'superman'),
+  (201, '$2a$10$z3whWUOA4B.Uqu2zwf2oi.5PzUQkpAfydtoKIR2qFYQs6nahNnaNO',   'theb@ddest'),
+  (202, '$2a$10$A4/kfzh0MqM/Y5r38s8i3.SqXxPOgTwhfMnL5Nrx61R2Q7Pr6pnrW',   'daniel'),
+  (203, '$2a$10$krCRwcxt6a/uzvjcbuae1OyulMh5dYrUfLFPE3SOn2yu7KfsLSSia',   'carlos'),
+  (204, '$2a$10$JsL4WH.cUFTF4Yhwx8ONQeW0mD32xXZT4TlOaAWoCbnKe/xmV9vcu',   'luis1'),
+  (205, '$2a$10$Bdpng4F7gQ3hi9K/Zax2Z.MH6ZA/anN6YS55tQdKv.ykWCt6eWLQy',   'rose1'),
+  (206, '$2a$10$slJT6QliTTTbthIk9TMjuu8NmJdSEEPo40rDrq/PgbjU5GyPtZxVO',   'josh1')
 ON CONFLICT (username) DO NOTHING;
 
 

--- a/src/test/java/com/anonymousibex/Agents/of/Revature/config/SessionAuthenticationFilterTest.java
+++ b/src/test/java/com/anonymousibex/Agents/of/Revature/config/SessionAuthenticationFilterTest.java
@@ -1,0 +1,93 @@
+package com.anonymousibex.Agents.of.Revature.config;
+
+import com.anonymousibex.Agents.of.Revature.model.User;
+import com.anonymousibex.Agents.of.Revature.repository.UserRepository;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockHttpServletResponse;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+
+import jakarta.servlet.FilterChain;
+
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+class SessionAuthenticationFilterTest {
+
+    private SessionAuthenticationFilter filter;
+    private UserRepository userRepo;
+
+    @BeforeEach
+    void setUp() {
+        userRepo = mock(UserRepository.class);
+        filter = new SessionAuthenticationFilter(userRepo);
+        // clear SecurityContext between tests
+        SecurityContextHolder.clearContext();
+    }
+
+    @AfterEach
+    void tearDown() {
+        SecurityContextHolder.clearContext();
+    }
+
+    @Test
+    void whenSessionContainsUserId_thenSecurityContextIsPopulated() throws Exception {
+        // arrange
+        MockHttpServletRequest req = new MockHttpServletRequest();
+        MockHttpServletResponse res = new MockHttpServletResponse();
+        FilterChain chain = mock(FilterChain.class);
+
+        // put userId in session
+        req.getSession(true).setAttribute("userId", 123L);
+
+        User u = new User();
+        u.setId(123L);
+        u.setUsername("bob");
+        when(userRepo.findById(123L)).thenReturn(Optional.of(u));
+
+        // act
+        filter.doFilterInternal(req, res, chain);
+
+        // assert
+        Authentication auth = SecurityContextHolder.getContext().getAuthentication();
+        assertThat(auth).isNotNull();
+        assertThat(auth.isAuthenticated()).isTrue();
+        assertThat(auth.getPrincipal()).isSameAs(u);
+
+        // and chain always proceeds
+        verify(chain).doFilter(req, res);
+    }
+
+    @Test
+    void whenNoSession_thenDoesNotAuthenticate() throws Exception {
+        MockHttpServletRequest req = new MockHttpServletRequest();
+        MockHttpServletResponse res = new MockHttpServletResponse();
+        FilterChain chain = mock(FilterChain.class);
+
+        filter.doFilterInternal(req, res, chain);
+
+        assertThat(SecurityContextHolder.getContext().getAuthentication()).isNull();
+        verify(chain).doFilter(req, res);
+    }
+
+    @Test
+    void whenSessionButNoUser_thenDoesNotAuthenticate() throws Exception {
+        MockHttpServletRequest req = new MockHttpServletRequest();
+        MockHttpServletResponse res = new MockHttpServletResponse();
+        FilterChain chain = mock(FilterChain.class);
+
+        req.getSession(true).setAttribute("userId", 999L);
+        when(userRepo.findById(999L)).thenReturn(Optional.empty());
+
+        filter.doFilterInternal(req, res, chain);
+
+        assertThat(SecurityContextHolder.getContext().getAuthentication()).isNull();
+        verify(chain).doFilter(req, res);
+    }
+}

--- a/src/test/java/com/anonymousibex/Agents/of/Revature/controller/AuthControllerTest.java
+++ b/src/test/java/com/anonymousibex/Agents/of/Revature/controller/AuthControllerTest.java
@@ -2,10 +2,8 @@ package com.anonymousibex.Agents.of.Revature.controller;
 
 import com.anonymousibex.Agents.of.Revature.dto.ResponseDto;
 import com.anonymousibex.Agents.of.Revature.dto.UserDto;
-import com.anonymousibex.Agents.of.Revature.model.Role;
 import com.anonymousibex.Agents.of.Revature.model.User;
 import com.anonymousibex.Agents.of.Revature.service.UserService;
-import com.anonymousibex.Agents.of.Revature.util.UserUtils;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import jakarta.servlet.http.HttpSession;
@@ -37,7 +35,7 @@ public class AuthControllerTest {
     @Test
     void testSignup() {
         User user = new User();
-        UserDto userDto = new UserDto(1L,"agent007", Role.USER);
+        UserDto userDto = new UserDto(1L,"agent007");
         when(userService.createUser(user)).thenReturn(userDto);
 
         ResponseEntity<UserDto> result = authController.signup(user);
@@ -82,7 +80,7 @@ public class AuthControllerTest {
         user.setId(42L);
         user.setUsername("agent007");
 
-        UserDto dto = new UserDto(42L, "agent007", Role.USER);
+        UserDto dto = new UserDto(42L, "agent007");
 
         when(userService.getCurrentUserBySession(request)).thenReturn(user);
 

--- a/src/test/java/com/anonymousibex/Agents/of/Revature/service/UserServiceTest.java
+++ b/src/test/java/com/anonymousibex/Agents/of/Revature/service/UserServiceTest.java
@@ -2,10 +2,8 @@ package com.anonymousibex.Agents.of.Revature.service;
 
 import com.anonymousibex.Agents.of.Revature.dto.UserDto;
 import com.anonymousibex.Agents.of.Revature.exception.*;
-import com.anonymousibex.Agents.of.Revature.model.Role;
 import com.anonymousibex.Agents.of.Revature.model.User;
 import com.anonymousibex.Agents.of.Revature.repository.UserRepository;
-import com.anonymousibex.Agents.of.Revature.util.UserUtils;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpSession;
 import org.junit.jupiter.api.BeforeEach;

--- a/src/test/java/com/anonymousibex/Agents/of/Revature/util/UserUtilsTest.java
+++ b/src/test/java/com/anonymousibex/Agents/of/Revature/util/UserUtilsTest.java
@@ -1,7 +1,6 @@
 package com.anonymousibex.Agents.of.Revature.util;
 
 import com.anonymousibex.Agents.of.Revature.dto.UserDto;
-import com.anonymousibex.Agents.of.Revature.model.Role;
 import com.anonymousibex.Agents.of.Revature.model.User;
 import jakarta.servlet.http.Cookie;
 import jakarta.servlet.http.HttpServletResponse;
@@ -49,13 +48,11 @@ class UserUtilsTest {
         User user = new User();
         user.setId(123L);
         user.setUsername("jdoe");
-        user.setRole(Role.ADMIN);
 
         UserDto dto = UserUtils.toUserDto(user);
 
         assertThat(dto.getId()).isEqualTo(123L);
         assertThat(dto.getUsername()).isEqualTo("jdoe");
-        assertThat(dto.getRole()).isEqualTo(Role.ADMIN);
     }
 
     // ------ clearSessionCookie test ------


### PR DESCRIPTION
…or SessionAuthFilter

**Pull Request:** removed role from user, added auto‑drop in `application.properties`, added testing for `SessionAuthFilter`

---

### 📖 Overview

This PR makes three related changes:

1. **Remove `role` from the `User` model**
   All users are now treated equally. We’ve purged the enum `Role` and any code, configuration, or tests that dealt with user roles/permissions.

2. **Enable automatic schema drop & recreation**
   In `application.properties` we’ve set:

   ```properties
   spring.jpa.hibernate.ddl-auto=create-drop
   ```

   (or `drop-and-create` depending on dialect) so that local databases are reset on each startup. This ensures a clean schema for development & testing without manual `DROP` statements.

3. **Add unit tests for `SessionAuthenticationFilter`**

   * A new test class, **`SessionAuthenticationFilterTest`**, verifies that:

     * A valid `userId` in session yields a populated `SecurityContext` with an authenticated principal.
     * Missing or expired session attributes correctly bypass authentication.
   * We mock the `UserRepository` and an in‑memory `HttpSession` to drive each scenario.

---

### 🔍 Detailed Changes

#### 1. Model & Security Cleanup

* **`User`**

  * Removed the `Role role` field and corresponding enum.
  * Cleaned up all controllers, services, DTOs, tests that referenced `user.getRole()`.
* **`SessionAuthenticationFilter`**

  * No longer reads `user.getRole()`. Instead, assigns a single hard‑coded authority (e.g. `ROLE_USER`) or leaves the `authorities` list empty if roles are fully deprecated.
  * Updated imports & constructor injection accordingly.

#### 2. Database Schema Management

* **`application.properties`**

  ```diff
  - spring.jpa.hibernate.ddl-auto=update
  + spring.jpa.hibernate.ddl-auto=create-drop
  ```

  * Enables automatic dropping and re-creation of the schema on each app start.
  * Eliminates the need to manually drop tables when structure changes.

#### 3. Testing `SessionAuthenticationFilter`

* **`SessionAuthenticationFilterTest`**

  * Simulates a `HttpServletRequest` with a session containing `userId`.
  * Mocks `UserRepository#findById` to return a `User` entity.
  * Verifies that after `doFilterInternal`, the `SecurityContextHolder` holds an authenticated `Authentication` with our test user.
  * Confirms that when no session or no `userId` is present, the filter does *not* set an authentication.
  * Covers edge cases: session invalidation, missing repo entry, etc.

---

### 🧪 Verification Steps

1. **Run all unit tests**

   ```bash
   ./mvnw test
   ```

   Ensure **100%** pass, especially the new `SessionAuthenticationFilterTest`.

2. **Manual smoke test**

   * Start the application; verify the schema is re‑created in your local Postgres/MySQL.
   * Perform a login to create a session.
   * Hit a protected endpoint; inspect `SecurityContext` via debugger or by adding a dummy controller that returns the authenticated principal’s username.

3. **Review cleanup**

   * Search for any lingering references to `Role`, `ROLE_…` authorities in controllers or config.
   * Confirm CORS, JWT, or other security configs remain unaffected.

---

### 🚀 Next Steps

* Once merged, fellow contributors will no longer need to manage database cleanup manually.
* We can revisit fine‑grained authorization later (e.g. via method‑level `@PreAuthorize`), but for now all authenticated users share the same access level.

---

Please let me know if you spot any oversights or have suggestions on the authority assignment in the `SessionAuthenticationFilter`. Thank you!
